### PR TITLE
Adjust selection overlay visuals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "SnapText",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "SnapText", targets: ["SnapText"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "SnapText",
+            path: "Sources/SnapText"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # SnapText
+
+SnapText is a native macOS menu bar utility that captures on-screen text with a single hotkey. It layers a lightweight selection overlay on top of the current display, performs on-device OCR, and copies the recognized text to the clipboard with optional toast feedback. The MVP prioritises speed (<2s OCR on 1080p selections) and local processing for privacy.
+
+## Highlights
+- **Instant capture:** Default shortcut `⌘⇧2` launches a drag-to-select overlay; Escape or right-click cancels silently.
+- **On-device OCR:** Uses the macOS Vision framework first and automatically falls back to Tesseract when available. Failure messaging is intentionally engine-agnostic.
+- **Clipboard ready:** Successful captures write directly to the clipboard and can surface an optional confirmation toast.
+- **Menu bar presence:** Status item with quick “Capture Text”, Preferences, and Quit entries keeps the utility discoverable without a Dock icon.
+- **Configurable preferences:** Users can remap the shortcut (modifier combos only), toggle the confirmation toast, select the OCR language (English for MVP), and opt into launch at login.
+
+## Project Structure
+```
+Package.swift
+Sources/
+  SnapText/
+    Application/        // App lifecycle, status item, and global hotkey wiring
+    Capture/            // Selection overlay windows and screenshot pipeline
+    Clipboard/          // Clipboard manager
+    OCR/                // Vision + Tesseract OCR services and result models
+    Permissions/        // Screen recording permission helper
+    Preferences/        // Preferences view + view model
+    Settings/           // User defaults-backed settings model
+    UI/                 // Toast presenter, hotkey recorder, reusable views
+    Utilities/          // Login item manager, NSScreen helpers
+prd.md
+planning.md
+```
+
+## Getting Started
+1. Open the repository in Xcode 15+ (macOS 14 SDK).
+2. Use `File > Open...` and select `Package.swift` to generate an executable scheme for the SwiftUI app.
+3. Ensure [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) and the `TesseractOCRiOS`/macOS bindings are available if you want fallback OCR at runtime. Without it, SnapText logs a warning and surfaces the generic failure toast when Vision also fails.
+4. Build & run the `SnapText` scheme. Grant screen recording permission when prompted.
+
+## Usage Notes
+- Press `⌘⇧2` (or your remapped shortcut) to invoke capture mode.
+- Drag to highlight the region that contains text; SnapText auto-downscales large selections to preserve the <2s performance target.
+- On success, text is copied to the clipboard and the optional toast reads “Copied to Clipboard.” Failures render the non-specific toast “Text could not be captured.”
+- Preferences (⌘,) let you toggle the toast, adjust the hotkey, choose OCR language, and control launch-at-login behaviour.
+
+## Permissions & Privacy
+- SnapText requires the macOS **Screen Recording** entitlement to read pixels. A single in-app explainer precedes the standard system dialog.
+- OCR is processed entirely on-device. No capture data leaves the user’s Mac.
+
+## Testing
+Automated tests are not included for the MVP; manual verification against known samples is recommended per the PRD. When running locally, validate:
+- OCR speed on 1080p selections (<2 seconds target).
+- Idle resource usage (≤5% CPU, <100 MB RAM) via Activity Monitor.
+- Shortcut conflicts on Apple Silicon MacBook Pro/Air and one Intel Mac, across Retina, 4K, and 1080p displays.
+
+## Roadmap
+Future phases (see `planning.md`) add multilingual OCR, capture history, export formats, and richer notification options while keeping the MVP minimal.

--- a/Sources/SnapText/Application/Hotkeys/GlobalHotkeyManager.swift
+++ b/Sources/SnapText/Application/Hotkeys/GlobalHotkeyManager.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Carbon
+
+final class GlobalHotkeyManager {
+    static let shared = GlobalHotkeyManager()
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private var callback: (() -> Void)?
+
+    private init() {
+        installEventHandlerIfNeeded()
+    }
+
+    deinit {
+        unregister()
+        if let handler = eventHandler {
+            RemoveEventHandler(handler)
+        }
+    }
+
+    func register(configuration: HotkeyConfiguration, handler: @escaping () -> Void) {
+        unregister()
+        callback = handler
+
+        var hotKeyID = EventHotKeyID(signature: OSType(UInt32("SNAP".fourCharCodeValue)), id: 1)
+        let status = RegisterEventHotKey(
+            configuration.keyCode,
+            configuration.modifierFlags.carbonFlags,
+            hotKeyID,
+            GetEventDispatcherTarget(),
+            0,
+            &hotKeyRef
+        )
+
+        if status != noErr {
+            NSLog("Failed to register hotkey with status: \(status)")
+        }
+    }
+
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+    }
+
+    private func installEventHandlerIfNeeded() {
+        guard eventHandler == nil else { return }
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+
+        InstallEventHandler(GetEventDispatcherTarget(), { _, eventRef, userData in
+            guard let userData else { return noErr }
+            let unmanaged = Unmanaged<GlobalHotkeyManager>.fromOpaque(userData)
+            let manager = unmanaged.takeUnretainedValue()
+            manager.callback?()
+            return noErr
+        }, 1, &eventType, UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()), &eventHandler)
+    }
+}
+
+private extension NSEvent.ModifierFlags {
+    var carbonFlags: UInt32 {
+        var carbonFlags: UInt32 = 0
+        if contains(.command) { carbonFlags |= UInt32(cmdKey) }
+        if contains(.option) { carbonFlags |= UInt32(optionKey) }
+        if contains(.control) { carbonFlags |= UInt32(controlKey) }
+        if contains(.shift) { carbonFlags |= UInt32(shiftKey) }
+        return carbonFlags
+    }
+}
+
+private extension String {
+    var fourCharCodeValue: UInt32 {
+        var result: UInt32 = 0
+        for scalar in unicodeScalars {
+            result = (result << 8) + UInt32(scalar.value)
+        }
+        return result
+    }
+}

--- a/Sources/SnapText/Application/Hotkeys/HotkeyConfiguration.swift
+++ b/Sources/SnapText/Application/Hotkeys/HotkeyConfiguration.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+struct HotkeyConfiguration: Codable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case keyCode
+        case modifierFlags
+    }
+
+    let keyCode: UInt32
+    let modifierFlags: NSEvent.ModifierFlags
+
+    init(keyCode: UInt32, modifierFlags: NSEvent.ModifierFlags) {
+        self.keyCode = keyCode
+        self.modifierFlags = modifierFlags
+    }
+
+    static let `default` = HotkeyConfiguration(
+        keyCode: 0x13, // '2' key in macOS virtual keycode table
+        modifierFlags: [.command, .shift]
+    )
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.keyCode = try container.decode(UInt32.self, forKey: .keyCode)
+        let rawFlags = try container.decode(UInt.self, forKey: .modifierFlags)
+        self.modifierFlags = NSEvent.ModifierFlags(rawValue: rawFlags)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(keyCode, forKey: .keyCode)
+        try container.encode(modifierFlags.rawValue, forKey: .modifierFlags)
+    }
+}

--- a/Sources/SnapText/Application/Hotkeys/KeyCodeTranslator.swift
+++ b/Sources/SnapText/Application/Hotkeys/KeyCodeTranslator.swift
@@ -1,0 +1,63 @@
+import AppKit
+
+enum KeyCodeTranslator {
+    static func displayName(for keyCode: UInt32) -> String {
+        if let special = specialKeyNames[keyCode] {
+            return special
+        }
+
+        let keyboard = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
+        guard let rawLayoutData = TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData) else {
+            return "Key \(keyCode)"
+        }
+
+        let layoutData = unsafeBitCast(rawLayoutData, to: CFData.self) as Data
+        guard let keyLayout = layoutData.withUnsafeBytes({ (pointer: UnsafeRawBufferPointer) -> UnsafePointer<UCKeyboardLayout>? in
+            return pointer.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self)
+        }) else {
+            return "Key \(keyCode)"
+        }
+
+        var deadKeyState: UInt32 = 0
+        let maxLength = 4
+        var chars: [UniChar] = Array(repeating: 0, count: maxLength)
+        var actualLength = 0
+
+        let status = UCKeyTranslate(
+            keyLayout,
+            UInt16(keyCode),
+            UInt16(kUCKeyActionDisplay),
+            0,
+            UInt32(LMGetKbdType()),
+            UInt32(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            maxLength,
+            &actualLength,
+            &chars
+        )
+
+        if status == noErr, actualLength > 0 {
+            return String(utf16CodeUnits: chars, count: actualLength)
+        } else {
+            return "Key \(keyCode)"
+        }
+    }
+
+    static func isFunctionKey(_ keyCode: UInt16) -> Bool {
+        functionKeyRange.contains(Int(keyCode))
+    }
+
+    private static let functionKeyRange = 122...135
+
+    private static let specialKeyNames: [UInt32: String] = [
+        0x24: "↩", // return
+        0x30: "⇥", // tab
+        0x31: "Space",
+        0x33: "⌫", // delete
+        0x35: "⎋", // escape
+        0x7B: "←",
+        0x7C: "→",
+        0x7D: "↓",
+        0x7E: "↑"
+    ]
+}

--- a/Sources/SnapText/Application/SnapTextApp.swift
+++ b/Sources/SnapText/Application/SnapTextApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct SnapTextApp: App {
+    @NSApplicationDelegateAdaptor(SnapTextAppDelegate.self) private var appDelegate
+    @StateObject private var settings = UserSettings.shared
+
+    var body: some Scene {
+        Settings {
+            PreferencesView(viewModel: PreferencesViewModel(settings: settings))
+                .frame(width: 420, height: 320)
+        }
+    }
+}

--- a/Sources/SnapText/Application/SnapTextAppDelegate.swift
+++ b/Sources/SnapText/Application/SnapTextAppDelegate.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Combine
+
+final class SnapTextAppDelegate: NSObject, NSApplicationDelegate {
+    private let settings = UserSettings.shared
+    private lazy var statusItemController = StatusItemController()
+    private lazy var captureController = CaptureController(settings: settings)
+    private lazy var toastPresenter = ToastPresenter(settings: settings)
+    private lazy var clipboardManager = ClipboardManager()
+    private lazy var permissionManager = ScreenPermissionManager()
+    private let hotkeyManager = GlobalHotkeyManager.shared
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+        statusItemController.onCaptureRequested = { [weak self] in
+            self?.startCapture()
+        }
+        statusItemController.onPreferencesRequested = {
+            NSApp.activate(ignoringOtherApps: true)
+            let modernSelector = Selector(("showSettingsWindow:"))
+            let legacySelector = Selector(("showPreferencesWindow:"))
+            let selector = NSApp.responds(to: modernSelector) ? modernSelector : legacySelector
+            NSApp.sendAction(selector, to: nil, from: nil)
+        }
+        statusItemController.onQuitRequested = {
+            NSApp.terminate(nil)
+        }
+
+        registerHotkey(settings.hotkey)
+        observeSettings()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        hotkeyManager.unregister()
+    }
+
+    private func startCapture() {
+        permissionManager.ensurePermission { [weak self] granted in
+            guard let self else { return }
+            guard granted else {
+                self.toastPresenter.show(message: "Text could not be captured.")
+                return
+            }
+
+            self.captureController.beginCapture { result in
+                switch result {
+                case let .success(ocrResult):
+                    self.clipboardManager.copy(ocrResult.text)
+                    self.toastPresenter.show(message: "Copied to Clipboard")
+                case let .failure(error):
+                    switch error {
+                    case .cancelled:
+                        break // Silent cancel per requirements
+                    case .screenshotFailed:
+                        self.toastPresenter.show(message: "Text could not be captured.")
+                    case let .ocrFailed(underlyingError):
+                        NSLog("OCR failed with error: \(underlyingError.localizedDescription)")
+                        self.toastPresenter.show(message: "Text could not be captured.")
+                    }
+                }
+            }
+        }
+    }
+
+    private func registerHotkey(_ configuration: HotkeyConfiguration) {
+        hotkeyManager.register(configuration: configuration) { [weak self] in
+            self?.startCapture()
+        }
+    }
+
+    private func observeSettings() {
+        settings.$hotkey
+            .sink { [weak self] configuration in
+                self?.registerHotkey(configuration)
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Sources/SnapText/Application/StatusItemController.swift
+++ b/Sources/SnapText/Application/StatusItemController.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+final class StatusItemController {
+    var onCaptureRequested: (() -> Void)?
+    var onPreferencesRequested: (() -> Void)?
+    var onQuitRequested: (() -> Void)?
+
+    private let statusItem: NSStatusItem
+
+    init() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        configureStatusItem()
+    }
+
+    private func configureStatusItem() {
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "text.viewfinder", accessibilityDescription: "SnapText")
+            button.imagePosition = .imageOnly
+            button.target = self
+            button.action = #selector(handlePrimaryAction)
+        }
+
+        let menu = NSMenu()
+        menu.addItem(withTitle: "Capture Text", action: #selector(handleCapture), keyEquivalent: "")
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(withTitle: "Preferences…", action: #selector(handlePreferences), keyEquivalent: ",")
+        menu.addItem(withTitle: "Quit SnapText", action: #selector(handleQuit), keyEquivalent: "q")
+        menu.items.forEach { $0.target = self }
+        statusItem.menu = menu
+    }
+
+    @objc private func handlePrimaryAction() {
+        statusItem.menu?.cancelTracking()
+        onCaptureRequested?()
+    }
+
+    @objc private func handleCapture() {
+        onCaptureRequested?()
+    }
+
+    @objc private func handlePreferences() {
+        onPreferencesRequested?()
+    }
+
+    @objc private func handleQuit() {
+        onQuitRequested?()
+    }
+}

--- a/Sources/SnapText/Capture/CaptureController.swift
+++ b/Sources/SnapText/Capture/CaptureController.swift
@@ -1,0 +1,120 @@
+import AppKit
+import CoreGraphics
+
+final class CaptureController {
+    private let settings: UserSettings
+    private let overlayController = SelectionOverlayWindowController()
+    private let ocrService: OCRServicing
+    private let processingQueue = DispatchQueue(label: "com.snaptext.capture", qos: .userInitiated)
+
+    init(settings: UserSettings, ocrService: OCRServicing = OCRService()) {
+        self.settings = settings
+        self.ocrService = ocrService
+    }
+
+    func beginCapture(completion: @escaping (Result<OCRResult, CaptureError>) -> Void) {
+        overlayController.beginSelection { [weak self] outcome in
+            guard let self else { return }
+            switch outcome {
+            case .cancelled:
+                completion(.failure(.cancelled))
+            case let .selected(rect, screen):
+                self.capture(rect: rect, screen: screen) { imageResult in
+                    switch imageResult {
+                    case let .success(image):
+                        self.recognize(image: image, completion: completion)
+                    case .failure:
+                        completion(.failure(.screenshotFailed))
+                    }
+                }
+            }
+        }
+    }
+
+    private func capture(rect: CGRect, screen: NSScreen, completion: @escaping (Result<CGImage, Error>) -> Void) {
+        processingQueue.async {
+            guard let displayID = screen.displayID,
+                  let fullImage = CGDisplayCreateImage(displayID) else {
+                DispatchQueue.main.async {
+                    completion(.failure(CaptureError.screenshotFailed))
+                }
+                return
+            }
+
+            let captureRect = self.convertToCaptureRect(rect: rect, screen: screen)
+            let bounds = CGRect(x: 0, y: 0, width: CGFloat(fullImage.width), height: CGFloat(fullImage.height))
+            let clampedRect = captureRect.intersection(bounds)
+            guard !clampedRect.isNull,
+                  let cropped = fullImage.cropping(to: clampedRect) else {
+                DispatchQueue.main.async {
+                    completion(.failure(CaptureError.screenshotFailed))
+                }
+                return
+            }
+
+            let optimizedImage = self.downscaleIfNeeded(image: cropped)
+            DispatchQueue.main.async {
+                completion(.success(optimizedImage))
+            }
+        }
+    }
+
+    private func recognize(image: CGImage, completion: @escaping (Result<OCRResult, CaptureError>) -> Void) {
+        ocrService.recognizeText(in: image, language: settings.ocrLanguage) { result in
+            switch result {
+            case let .success(ocrResult):
+                completion(.success(ocrResult))
+            case let .failure(error):
+                completion(.failure(.ocrFailed(error)))
+            }
+        }
+    }
+
+    private func downscaleIfNeeded(image: CGImage) -> CGImage {
+        let maxDimension: CGFloat = 2000
+        let width = CGFloat(image.width)
+        let height = CGFloat(image.height)
+        let largestDimension = max(width, height)
+        guard largestDimension > maxDimension else { return image }
+
+        let scale = maxDimension / largestDimension
+        let newSize = CGSize(width: width * scale, height: height * scale)
+
+        guard let colorSpace = image.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                data: nil,
+                width: Int(newSize.width),
+                height: Int(newSize.height),
+                bitsPerComponent: image.bitsPerComponent,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return image
+        }
+
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(origin: .zero, size: newSize))
+        return context.makeImage() ?? image
+    }
+
+    private func convertToCaptureRect(rect: CGRect, screen: NSScreen) -> CGRect {
+        let scale = screen.backingScaleFactor
+        let relativeX = rect.origin.x - screen.frame.origin.x
+        let relativeY = rect.origin.y - screen.frame.origin.y
+        let flippedY = screen.frame.height - relativeY - rect.height
+
+        return CGRect(
+            x: relativeX * scale,
+            y: flippedY * scale,
+            width: rect.width * scale,
+            height: rect.height * scale
+        ).integral
+    }
+}
+
+enum CaptureError: Error {
+    case cancelled
+    case screenshotFailed
+    case ocrFailed(Error)
+}

--- a/Sources/SnapText/Capture/SelectionOverlayWindowController.swift
+++ b/Sources/SnapText/Capture/SelectionOverlayWindowController.swift
@@ -1,0 +1,157 @@
+import AppKit
+
+enum SelectionOutcome {
+    case cancelled
+    case selected(rect: CGRect, screen: NSScreen)
+}
+
+final class SelectionOverlayWindowController {
+    private var windows: [NSWindow] = []
+    private var completion: ((SelectionOutcome) -> Void)?
+    private var monitors: [Any] = []
+
+    func beginSelection(completion: @escaping (SelectionOutcome) -> Void) {
+        guard windows.isEmpty else { return }
+        self.completion = completion
+        installMonitors()
+        createOverlayWindows()
+    }
+
+    private func finish(with outcome: SelectionOutcome) {
+        tearDown()
+        completion?(outcome)
+        completion = nil
+    }
+
+    private func createOverlayWindows() {
+        for screen in NSScreen.screens {
+            let window = SelectionOverlayWindow(screen: screen)
+            if let overlayView = window.contentView as? SelectionOverlayView {
+                overlayView.onSelectionFinished = { [weak self] rect in
+                    let globalRect = window.convertToScreen(rect)
+                    self?.finish(with: .selected(rect: globalRect, screen: screen))
+                }
+                overlayView.onSelectionCancelled = { [weak self] in
+                    self?.finish(with: .cancelled)
+                }
+                window.invalidateCursorRects(for: overlayView)
+            }
+            window.makeKeyAndOrderFront(nil)
+            windows.append(window)
+        }
+    }
+
+    private func installMonitors() {
+        if let keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { // escape key
+                self?.finish(with: .cancelled)
+                return nil
+            }
+            return event
+        } {
+            monitors.append(keyMonitor)
+        }
+
+        if let globalRightClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .rightMouseDown) { [weak self] _ in
+            self?.finish(with: .cancelled)
+        } {
+            monitors.append(globalRightClickMonitor)
+        }
+    }
+
+    private func tearDown() {
+        for window in windows {
+            window.orderOut(nil)
+        }
+        windows.removeAll()
+
+        for monitor in monitors {
+            NSEvent.removeMonitor(monitor)
+        }
+        monitors.removeAll()
+    }
+}
+
+private final class SelectionOverlayWindow: NSWindow {
+    init(screen: NSScreen) {
+        super.init(contentRect: screen.frame, styleMask: .borderless, backing: .buffered, defer: false, screen: screen)
+        isReleasedWhenClosed = false
+        ignoresMouseEvents = false
+        backgroundColor = .clear
+        isOpaque = false
+        level = .screenSaver
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        contentView = SelectionOverlayView(frame: screen.frame)
+        acceptsMouseMovedEvents = true
+    }
+}
+
+private final class SelectionOverlayView: NSView {
+    var onSelectionFinished: ((CGRect) -> Void)?
+    var onSelectionCancelled: (() -> Void)?
+
+    private var startPoint: CGPoint?
+    private var selectionRect: CGRect? {
+        didSet { needsDisplay = true }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        if let selectionRect {
+            let path = NSBezierPath(rect: selectionRect)
+            NSColor.controlAccentColor.withAlphaComponent(0.2).setFill()
+            path.fill()
+
+            path.lineWidth = 2
+            NSColor.white.setStroke()
+            path.stroke()
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        startPoint = convert(event.locationInWindow, from: nil)
+        selectionRect = CGRect(origin: startPoint ?? .zero, size: .zero)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let startPoint else { return }
+        let currentPoint = convert(event.locationInWindow, from: nil)
+        selectionRect = CGRect(x: min(startPoint.x, currentPoint.x),
+                               y: min(startPoint.y, currentPoint.y),
+                               width: abs(startPoint.x - currentPoint.x),
+                               height: abs(startPoint.y - currentPoint.y))
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard let selectionRect, selectionRect.width > 5, selectionRect.height > 5 else {
+            self.selectionRect = nil
+            onSelectionCancelled?()
+            return
+        }
+        self.selectionRect = nil
+        onSelectionFinished?(selectionRect)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        selectionRect = nil
+        onSelectionCancelled?()
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        discardCursorRects()
+        addCursorRect(bounds, cursor: .crosshair)
+    }
+}

--- a/Sources/SnapText/Clipboard/ClipboardManager.swift
+++ b/Sources/SnapText/Clipboard/ClipboardManager.swift
@@ -1,0 +1,9 @@
+import AppKit
+
+final class ClipboardManager {
+    func copy(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}

--- a/Sources/SnapText/OCR/OCRService.swift
+++ b/Sources/SnapText/OCR/OCRService.swift
@@ -1,0 +1,56 @@
+import CoreGraphics
+
+struct OCRResult {
+    let text: String
+    let engine: OCREngine
+}
+
+enum OCREngine {
+    case vision
+    case tesseract
+}
+
+protocol OCRServicing {
+    func recognizeText(in image: CGImage, language: OCRLanguage, completion: @escaping (Result<OCRResult, Error>) -> Void)
+}
+
+final class OCRService: OCRServicing {
+    private let visionService: VisionOCRService
+    private let tesseractService: TesseractOCRService
+
+    init(visionService: VisionOCRService = VisionOCRService(), tesseractService: TesseractOCRService = TesseractOCRService()) {
+        self.visionService = visionService
+        self.tesseractService = tesseractService
+    }
+
+    func recognizeText(in image: CGImage, language: OCRLanguage, completion: @escaping (Result<OCRResult, Error>) -> Void) {
+        visionService.recognize(image: image, language: language) { [weak self] result in
+            switch result {
+            case let .success(text):
+                completion(.success(OCRResult(text: text, engine: .vision)))
+            case let .failure(error):
+                self?.attemptFallback(image: image, language: language, primaryError: error, completion: completion)
+            }
+        }
+    }
+
+    private func attemptFallback(
+        image: CGImage,
+        language: OCRLanguage,
+        primaryError: Error,
+        completion: @escaping (Result<OCRResult, Error>) -> Void
+    ) {
+        tesseractService.recognize(image: image, language: language) { fallbackResult in
+            switch fallbackResult {
+            case let .success(text):
+                completion(.success(OCRResult(text: text, engine: .tesseract)))
+            case let .failure(fallbackError):
+                completion(.failure(OCRFailure.primaryAndFallbackFailed(primary: primaryError, fallback: fallbackError)))
+            }
+        }
+    }
+}
+
+enum OCRFailure: Error {
+    case primaryAndFallbackFailed(primary: Error, fallback: Error)
+}

--- a/Sources/SnapText/OCR/TesseractOCRService.swift
+++ b/Sources/SnapText/OCR/TesseractOCRService.swift
@@ -1,0 +1,67 @@
+import CoreGraphics
+
+#if canImport(TesseractOCR)
+import TesseractOCR
+#if canImport(UIKit)
+import UIKit
+typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformImage = NSImage
+#endif
+
+final class TesseractOCRService {
+    func recognize(image: CGImage, language: OCRLanguage, completion: @escaping (Result<String, Error>) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let tesseract = G8Tesseract(language: language.rawValue) else {
+                DispatchQueue.main.async {
+                    completion(.failure(TesseractError.initializationFailed))
+                }
+                return
+            }
+
+            tesseract.engineMode = .tesseractOnly
+            tesseract.pageSegmentationMode = .auto
+            tesseract.maximumRecognitionTime = 2.0
+#if canImport(UIKit)
+            let platformImage = PlatformImage(cgImage: image)
+            tesseract.image = platformImage
+#elseif canImport(AppKit)
+            let size = NSSize(width: CGFloat(image.width), height: CGFloat(image.height))
+            let platformImage = PlatformImage(cgImage: image, size: size)
+            tesseract.image = platformImage
+#endif
+            tesseract.recognize()
+
+            let text = tesseract.recognizedText ?? ""
+            DispatchQueue.main.async {
+                if text.isEmpty {
+                    completion(.failure(TesseractError.noTextFound))
+                } else {
+                    completion(.success(text))
+                }
+            }
+        }
+    }
+}
+
+enum TesseractError: Error {
+    case initializationFailed
+    case noTextFound
+}
+
+#else
+
+final class TesseractOCRService {
+    func recognize(image: CGImage, language: OCRLanguage, completion: @escaping (Result<String, Error>) -> Void) {
+        DispatchQueue.main.async {
+            completion(.failure(TesseractUnavailableError.missingDependency))
+        }
+    }
+}
+
+enum TesseractUnavailableError: Error {
+    case missingDependency
+}
+
+#endif

--- a/Sources/SnapText/OCR/VisionOCRService.swift
+++ b/Sources/SnapText/OCR/VisionOCRService.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Vision
+
+final class VisionOCRService {
+    private let queue = DispatchQueue(label: "com.snaptext.ocr.vision", qos: .userInitiated)
+
+    func recognize(image: CGImage, language: OCRLanguage, completion: @escaping (Result<String, Error>) -> Void) {
+        queue.async {
+            let request = VNRecognizeTextRequest { request, error in
+                if let error {
+                    DispatchQueue.main.async {
+                        completion(.failure(error))
+                    }
+                    return
+                }
+
+                guard let results = request.results as? [VNRecognizedTextObservation] else {
+                    DispatchQueue.main.async {
+                        completion(.failure(OCRProcessingError.noTextFound))
+                    }
+                    return
+                }
+
+                let textLines: [String] = results.compactMap { observation in
+                    observation.topCandidates(1).first?.string
+                }
+
+                let output = textLines.joined(separator: "\n")
+                DispatchQueue.main.async {
+                    completion(.success(output))
+                }
+            }
+
+            request.recognitionLanguages = [language.visionRecognitionLanguage]
+            request.usesCPUOnly = false
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = false
+
+            let handler = VNImageRequestHandler(cgImage: image, options: [:])
+            do {
+                try handler.perform([request])
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+}
+
+enum OCRProcessingError: Error {
+    case noTextFound
+}

--- a/Sources/SnapText/Permissions/ScreenPermissionManager.swift
+++ b/Sources/SnapText/Permissions/ScreenPermissionManager.swift
@@ -1,0 +1,45 @@
+import AppKit
+import CoreGraphics
+
+final class ScreenPermissionManager {
+    private let onboardingKey = "ScreenPermissionOnboardingShown"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func ensurePermission(grantedHandler: @escaping (Bool) -> Void) {
+        if CGPreflightScreenCaptureAccess() {
+            grantedHandler(true)
+            return
+        }
+
+        presentOnboardingIfNeeded()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let granted = CGRequestScreenCaptureAccess()
+            DispatchQueue.main.async {
+                grantedHandler(granted)
+            }
+        }
+    }
+
+    func presentOnboardingIfNeeded() {
+        guard userDefaults.bool(forKey: onboardingKey) == false else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "SnapText needs screen access"
+        alert.informativeText = "To capture text from your screen, macOS requires granting SnapText Screen Recording permission. You'll see the standard system prompt next."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Continue")
+
+        if let window = NSApp.mainWindow {
+            alert.beginSheetModal(for: window) { _ in }
+        } else {
+            alert.runModal()
+        }
+
+        userDefaults.set(true, forKey: onboardingKey)
+    }
+}

--- a/Sources/SnapText/Preferences/PreferencesView.swift
+++ b/Sources/SnapText/Preferences/PreferencesView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct PreferencesView: View {
+    @ObservedObject var viewModel: PreferencesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Form {
+                Section(header: Text("Capture")) {
+                    LabeledContent("Global Hotkey") {
+                        HotkeyRecorderView(configuration: $viewModel.hotkey, displayString: viewModel.displayString)
+                    }
+
+                    Picker("OCR Language", selection: $viewModel.selectedLanguage) {
+                        ForEach(viewModel.availableLanguages) { language in
+                            Text(language.displayName).tag(language)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section(header: Text("Feedback")) {
+                    Toggle("Show confirmation toast", isOn: $viewModel.showToast)
+                        .toggleStyle(.switch)
+                }
+
+                Section(header: Text("Startup")) {
+                    Toggle("Launch SnapText at login", isOn: $viewModel.launchAtLogin)
+                        .toggleStyle(.switch)
+                }
+            }
+            .formStyle(.grouped)
+
+            Text("Changes are saved automatically.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding(24)
+    }
+}
+
+struct PreferencesView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreferencesView(viewModel: PreferencesViewModel(settings: UserSettings.shared))
+            .frame(width: 420, height: 320)
+    }
+}

--- a/Sources/SnapText/Preferences/PreferencesViewModel.swift
+++ b/Sources/SnapText/Preferences/PreferencesViewModel.swift
@@ -1,0 +1,93 @@
+import Combine
+
+final class PreferencesViewModel: ObservableObject {
+    @Published var hotkey: HotkeyConfiguration {
+        didSet {
+            guard hotkey != settings.hotkey else { return }
+            settings.hotkey = hotkey
+        }
+    }
+
+    @Published var showToast: Bool {
+        didSet {
+            guard showToast != settings.showToast else { return }
+            settings.showToast = showToast
+        }
+    }
+
+    @Published var launchAtLogin: Bool {
+        didSet {
+            guard launchAtLogin != settings.launchAtLogin else { return }
+            settings.launchAtLogin = launchAtLogin
+            loginItemManager.setLaunchAtLogin(launchAtLogin)
+        }
+    }
+
+    @Published var selectedLanguage: OCRLanguage {
+        didSet {
+            guard selectedLanguage != settings.ocrLanguage else { return }
+            settings.ocrLanguage = selectedLanguage
+        }
+    }
+
+    let availableLanguages = OCRLanguage.allCases
+
+    private let settings: UserSettings
+    private let loginItemManager: LoginItemManaging
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(settings: UserSettings, loginItemManager: LoginItemManaging = LoginItemManager()) {
+        self.settings = settings
+        self.loginItemManager = loginItemManager
+        self.hotkey = settings.hotkey
+        self.showToast = settings.showToast
+        self.launchAtLogin = settings.launchAtLogin
+        self.selectedLanguage = settings.ocrLanguage
+
+        bindSettings()
+
+        if launchAtLogin {
+            loginItemManager.setLaunchAtLogin(true)
+        }
+    }
+
+    func displayString(for hotkey: HotkeyConfiguration) -> String {
+        var parts: [String] = []
+        if hotkey.modifierFlags.contains(.command) { parts.append("⌘") }
+        if hotkey.modifierFlags.contains(.option) { parts.append("⌥") }
+        if hotkey.modifierFlags.contains(.control) { parts.append("⌃") }
+        if hotkey.modifierFlags.contains(.shift) { parts.append("⇧") }
+        parts.append(KeyCodeTranslator.displayName(for: hotkey.keyCode))
+        return parts.joined(separator: " ")
+    }
+
+    private func bindSettings() {
+        settings.$hotkey
+            .sink { [weak self] newValue in
+                guard let self, self.hotkey != newValue else { return }
+                self.hotkey = newValue
+            }
+            .store(in: &cancellables)
+
+        settings.$showToast
+            .sink { [weak self] newValue in
+                guard let self, self.showToast != newValue else { return }
+                self.showToast = newValue
+            }
+            .store(in: &cancellables)
+
+        settings.$launchAtLogin
+            .sink { [weak self] newValue in
+                guard let self, self.launchAtLogin != newValue else { return }
+                self.launchAtLogin = newValue
+            }
+            .store(in: &cancellables)
+
+        settings.$ocrLanguage
+            .sink { [weak self] newValue in
+                guard let self, self.selectedLanguage != newValue else { return }
+                self.selectedLanguage = newValue
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Sources/SnapText/Settings/UserSettings.swift
+++ b/Sources/SnapText/Settings/UserSettings.swift
@@ -1,0 +1,84 @@
+import AppKit
+import Combine
+
+final class UserSettings: ObservableObject {
+    static let shared = UserSettings()
+
+    enum Keys: String {
+        case hotkey
+        case ocrLanguage
+        case showToast
+        case launchAtLogin
+    }
+
+    @Published var hotkey: HotkeyConfiguration {
+        didSet { persistHotkey() }
+    }
+
+    @Published var ocrLanguage: OCRLanguage {
+        didSet { persistLanguage() }
+    }
+
+    @Published var showToast: Bool {
+        didSet { persistToggle(.showToast, value: showToast) }
+    }
+
+    @Published var launchAtLogin: Bool {
+        didSet { persistToggle(.launchAtLogin, value: launchAtLogin) }
+    }
+
+    private let userDefaults: UserDefaults
+
+    private init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        if let hotkeyData = userDefaults.data(forKey: Keys.hotkey.rawValue),
+           let decoded = try? JSONDecoder().decode(HotkeyConfiguration.self, from: hotkeyData) {
+            hotkey = decoded
+        } else {
+            hotkey = .default
+        }
+
+        if let rawValue = userDefaults.string(forKey: Keys.ocrLanguage.rawValue),
+           let language = OCRLanguage(rawValue: rawValue) {
+            ocrLanguage = language
+        } else {
+            ocrLanguage = .english
+        }
+
+        showToast = userDefaults.object(forKey: Keys.showToast.rawValue) as? Bool ?? true
+        launchAtLogin = userDefaults.object(forKey: Keys.launchAtLogin.rawValue) as? Bool ?? false
+    }
+
+    private func persistHotkey() {
+        guard let data = try? JSONEncoder().encode(hotkey) else { return }
+        userDefaults.set(data, forKey: Keys.hotkey.rawValue)
+    }
+
+    private func persistLanguage() {
+        userDefaults.set(ocrLanguage.rawValue, forKey: Keys.ocrLanguage.rawValue)
+    }
+
+    private func persistToggle(_ key: Keys, value: Bool) {
+        userDefaults.set(value, forKey: key.rawValue)
+    }
+}
+
+enum OCRLanguage: String, CaseIterable, Identifiable {
+    case english = "en"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .english:
+            return "English"
+        }
+    }
+
+    var visionRecognitionLanguage: String {
+        switch self {
+        case .english:
+            return "en_US"
+        }
+    }
+}

--- a/Sources/SnapText/UI/HotkeyRecorderView.swift
+++ b/Sources/SnapText/UI/HotkeyRecorderView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import AppKit
+
+struct HotkeyRecorderView: View {
+    @Binding var configuration: HotkeyConfiguration
+    let displayString: (HotkeyConfiguration) -> String
+
+    @State private var isRecording = false
+    @State private var eventMonitor: Any?
+
+    var body: some View {
+        HStack {
+            Text(displayString(configuration))
+                .font(.system(.body, design: .monospaced))
+                .padding(.vertical, 6)
+                .padding(.horizontal, 8)
+                .background(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3)))
+                .frame(minWidth: 120, alignment: .leading)
+
+            Button(isRecording ? "Press combination…" : "Change") {
+                toggleRecording()
+            }
+            .buttonStyle(.bordered)
+        }
+        .onDisappear {
+            tearDownMonitor()
+        }
+    }
+
+    private func toggleRecording() {
+        if isRecording {
+            tearDownMonitor()
+        } else {
+            startRecording()
+        }
+    }
+
+    private func startRecording() {
+        isRecording = true
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            handle(event: event)
+            return nil
+        }
+    }
+
+    private func tearDownMonitor() {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+        isRecording = false
+    }
+
+    private func handle(event: NSEvent) {
+        let sanitizedModifiers = event.modifierFlags.intersection([.command, .control, .option, .shift])
+        guard !sanitizedModifiers.isEmpty else {
+            tearDownMonitor()
+            return
+        }
+
+        guard !KeyCodeTranslator.isFunctionKey(event.keyCode) else {
+            tearDownMonitor()
+            return
+        }
+
+        let keyCode = UInt32(event.keyCode)
+        configuration = HotkeyConfiguration(keyCode: keyCode, modifierFlags: sanitizedModifiers)
+        tearDownMonitor()
+    }
+}

--- a/Sources/SnapText/UI/ToastPresenter.swift
+++ b/Sources/SnapText/UI/ToastPresenter.swift
@@ -1,0 +1,72 @@
+import AppKit
+import SwiftUI
+
+final class ToastPresenter {
+    private let settings: UserSettings
+    private var window: NSWindow?
+    private var hideWorkItem: DispatchWorkItem?
+
+    init(settings: UserSettings) {
+        self.settings = settings
+    }
+
+    func show(message: String) {
+        guard settings.showToast else { return }
+
+        DispatchQueue.main.async {
+            self.presentToast(message: message)
+        }
+    }
+
+    private func presentToast(message: String) {
+        let toastView = ToastView(message: message)
+        let hostingView = NSHostingView(rootView: toastView)
+        let contentSize = hostingView.fittingSize
+        hostingView.frame = NSRect(origin: .zero, size: contentSize)
+        let frame = NSRect(origin: .zero, size: contentSize)
+
+        let toastWindow: NSWindow
+        if let existing = window {
+            toastWindow = existing
+        } else {
+            toastWindow = NSWindow(
+                contentRect: frame,
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            toastWindow.isOpaque = false
+            toastWindow.backgroundColor = .clear
+            toastWindow.level = .statusBar
+            toastWindow.hasShadow = false
+            toastWindow.ignoresMouseEvents = true
+            window = toastWindow
+        }
+
+        toastWindow.contentView = hostingView
+        toastWindow.setContentSize(contentSize)
+        position(window: toastWindow, with: contentSize)
+        toastWindow.orderFrontRegardless()
+
+        scheduleDismissal()
+    }
+
+    private func position(window: NSWindow, with size: NSSize) {
+        guard let screen = NSScreen.main else { return }
+        let visibleFrame = screen.visibleFrame
+        let origin = CGPoint(
+            x: visibleFrame.maxX - size.width - 24,
+            y: visibleFrame.minY + 80
+        )
+        window.setFrame(NSRect(origin: origin, size: size), display: true)
+    }
+
+    private func scheduleDismissal() {
+        hideWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.window?.orderOut(nil)
+        }
+        hideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: workItem)
+    }
+}

--- a/Sources/SnapText/UI/ToastView.swift
+++ b/Sources/SnapText/UI/ToastView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ToastView: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .foregroundColor(.white)
+            .font(.system(size: 14, weight: .semibold))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+                .overlay(Color.black.opacity(0.3)))
+            .clipShape(Capsule())
+            .shadow(radius: 8)
+            .padding()
+    }
+}
+
+private struct VisualEffectView: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/SnapText/Utilities/LoginItemManager.swift
+++ b/Sources/SnapText/Utilities/LoginItemManager.swift
@@ -1,0 +1,20 @@
+import Foundation
+import ServiceManagement
+
+protocol LoginItemManaging {
+    func setLaunchAtLogin(_ enabled: Bool)
+}
+
+final class LoginItemManager: LoginItemManaging {
+    func setLaunchAtLogin(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                SMAppService.mainApp.unregister()
+            }
+        } catch {
+            NSLog("Failed to update login item: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/SnapText/Utilities/NSScreen+DisplayID.swift
+++ b/Sources/SnapText/Utilities/NSScreen+DisplayID.swift
@@ -1,0 +1,11 @@
+import AppKit
+import CoreGraphics
+
+extension NSScreen {
+    var displayID: CGDirectDisplayID? {
+        guard let number = deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+            return nil
+        }
+        return CGDirectDisplayID(number.uint32Value)
+    }
+}

--- a/planning.md
+++ b/planning.md
@@ -1,0 +1,29 @@
+# SnapText for Mac — Planning Document
+
+## Phase 1: MVP
+- OCR engine integration (Vision framework).  
+- Hotkey + overlay for capture.  
+- Copy text to clipboard.  
+- Menu bar app with preferences.  
+- Basic QA and submission.  
+
+## Phase 2: Enhancements
+- Add text cleanup (line breaks, hyphens).  
+- Expand language support.  
+- Notification customization.  
+- History log of captures.  
+
+## Phase 3: Advanced
+- Export formats (PDF, markdown).  
+- Multi-language auto-detection.  
+- Cloud sync for history (optional).  
+
+## Resources Needed
+- macOS developer with Swift/SwiftUI experience.  
+- Designer for lightweight overlay UI.  
+- QA tester for OCR accuracy and hotkey conflicts.  
+
+## Deliverables
+- Functional macOS app (dmg + App Store).  
+- Documentation: user guide, FAQ.  
+- Support site (landing page + feedback form).  

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,84 @@
+# SnapText for Mac
+
+## Product Requirements Document (PRD)
+
+**Owner:** Ari  
+**Version:** Draft v1.0  
+
+---
+
+## 1. Overview
+SnapText is a lightweight macOS utility that lets users instantly capture text from any portion of their screen and copy it to the clipboard. The app runs locally, prioritizes speed and privacy, and integrates with macOS system features (hotkeys, menu bar, clipboard).
+
+Goal: reduce the process of extracting text from an image, video, PDF, or any app on screen to a single keyboard shortcut.
+
+---
+
+## 2. Objectives & Success Criteria
+
+- **Primary Objective:** Enable users to capture text from any on-screen source in under 3 seconds.  
+- **Secondary Objectives:**  
+  - No internet required (local OCR).  
+  - Minimal system resource usage.  
+  - Seamless integration with macOS UX.  
+
+**Success Metrics:**  
+- OCR capture time < 2 seconds.  
+- Accuracy ≥ 95% for English text on clean screenshots.  
+- ≤ 5% CPU usage when idle.  
+- < 100 MB memory footprint.  
+
+---
+
+## 3. Key Features
+
+### Core
+- Screen area OCR capture via global hotkey.  
+- Drag rectangle to select screen area.  
+- Captured text automatically copied to clipboard.  
+- Menu bar app with preferences: hotkey mapping, OCR language, notifications, launch at startup.  
+- Offline OCR engine (macOS Vision framework, fallback Tesseract).  
+
+### Secondary (Phase 2)
+- History of past captures.  
+- Export as plain text, markdown, or PDF.  
+- Smart cleanup (remove line breaks, fix hyphenation).  
+- Multi-language auto-detect.  
+
+---
+
+## 4. User Stories
+
+- Student grabs text from a YouTube video lecture to paste into notes.  
+- Developer copies text from a non-selectable error dialog.  
+- Researcher extracts citations from scanned PDFs.  
+- Casual user copies phone numbers or addresses from an image.  
+
+---
+
+## 5. Technical Requirements
+
+- **Platform:** macOS 14+ (Sonoma, Sequoia).  
+- **Language:** Swift/SwiftUI.  
+- **OCR Engine:** macOS Vision framework (preferred), fallback Tesseract.  
+- **Performance:** OCR < 2s for 1080p screen area.  
+- **Privacy:** 100% local OCR, no cloud dependency.  
+- **Distribution:** Mac App Store + direct dmg.  
+
+---
+
+## 6. UI/UX
+
+- **Activation:** Global hotkey triggers dark overlay → drag to select region → OCR runs instantly.  
+- **Menu Bar:** Minimalist dropdown with “Capture Text,” Preferences, optional recent captures.  
+- **Feedback:** Silent copy by default; optional toast “Copied to Clipboard.”  
+
+---
+
+## 7. Timeline (MVP)
+
+- Week 1–2: OCR prototype, Vision framework integration.  
+- Week 3–4: Capture overlay + hotkey system.  
+- Week 5–6: Clipboard + menu bar app.  
+- Week 7: Preferences + polish.  
+- Week 8: QA, bug fixes, App Store submission.  


### PR DESCRIPTION
## Summary
- scaffold the SnapText SwiftUI menu bar app with status item, global hotkey registration, and permissions onboarding
- add capture overlay, screenshot pipeline, and OCR services with Vision-first processing plus automatic Tesseract fallback and clipboard/toast feedback
- build preferences UI for hotkey remapping, language selection, launch-at-login and toast toggles, and document requirements in README, prd.md, and planning.md
- fix the preferences menu action by using a compatible selector and remove the unsupported Info.plist resource entry so the package builds in Xcode
- update the selection overlay to keep the screen clear and display a crosshair cursor during capture

## Testing
- not run (macOS-specific project cannot be built in this Linux CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68c95389c7f0832297dc9511474afdfd